### PR TITLE
Add Rimefeller compatibility patch.

### DIFF
--- a/Patches/Rimefeller.xml
+++ b/Patches/Rimefeller.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Rimefeller</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <success>Always</success>
+      <operations>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName = "RimNauts2_PodLauncher"]/comps</xpath>
+          <value>
+            <li Class="Rimefeller.CompProperties_Pipe"/>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName = "RimNauts2_PodLauncher"]</xpath>
+          <value>
+            <tickerType>Normal</tickerType>
+          </value>
+        </li>
+      </operations>
+    </match>
+  </Operation>
+</Patch>

--- a/Workshop/description.txt
+++ b/Workshop/description.txt
@@ -92,7 +92,7 @@ Main programmer: [url=https://ko-fi.com/sindre0830]sindre0830[/url]
 Main artist: [url=https://ko-fi.com/detvisor]DetVisor[/url]
 
 Workshop infographic template: [url=https://ko-fi.com/bingbopjeebo8087]Bing Bop Jeebo[/url]
-
+Rimefeller Compatibility patch: [url=https://steamcommunity.com/id/Jiopaba/myworkshopfiles/?appid=294100]Jiopaba[/ur]
 
 This mod is a continuation of [url=https://steamcommunity.com/sharedfiles/filedetails/?id=2198026141]RimNauts 1[/url].  Please refer to that page for the original developer team and their contribution (Especially the C# wizard who made it all possible in the first place; [url=https://steamcommunity.com/profiles/76561198032541893/myworkshopfiles/]Nolabritt[/url]). We also continue to use the art created by [url=https://ko-fi.com/kasmex]Kasmex[/url] and [url=https://ko-fi.com/genomex]Genome-X.[/url]
 


### PR DESCRIPTION
Makes the Large Pod Launcher refuellable via direct connection to Rimefeller pipe networks which contain Chemfuel.

Adds the CompProperties_Pipe comp to the Large Pod Launcher.

Changes the ticker type of the Large Pod Launcher to normal.